### PR TITLE
Update README and add example usages

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ Next add the following to your crate:
 ```rust
 extern crate wbg_rand;
 
-use wbg_rand::{Rng, wasm_rand};
+use wbg_rand::{Rng, wasm_rng};
 ```
 
 The `rand` crate is reexported from the `wbg-rand` crate so the `Rng` trait here
 is the [same as it is upstream](https://docs.rs/rand/0.4.2/rand/trait.Rng.html).
 
-And now you use `wasm_rand` just like you would `thread_rng`!
+And now you use `wasm_rng` just like you would `thread_rng`!
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,24 @@ is the [same as it is upstream](https://docs.rs/rand/0.4.2/rand/trait.Rng.html).
 
 And now you use `wasm_rng` just like you would `thread_rng`!
 
+# Example Usages
+See the [Rng](https://docs.rs/rand/0.4.2/rand/trait.Rng.html) trait for more documentation.
+
+```rust
+use wbg_rand::{Rng, wasm_rng, math_random_rng};
+
+// get random boolean, `math_random_rng()` samples `Math.random` in JS every call
+let a: bool = math_random_rng().gen();
+println!("{}", a);
+
+// `wasm_rng()` only samples `Math.random` to re-seed periodically
+let n = wasm_rng().gen::<f64>();
+println!("{}", n);
+
+let r: usize = wasm_rng().gen_range(0, 10);
+println!("{}", r);
+```
+
 # License
 
 This project is licensed under either of

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,10 +6,28 @@
 //! periodically from `Math.random`.
 //!
 //! Users of `rand::thread_rng` should feel right at home with `wasm_rng`.
+//!
+//! # Example Usages
+//! See the Rng trait for more examples: https://docs.rs/rand/0.5.0-pre.2/rand/trait.Rng.html.
+//!
+//! ```no_run
+//! use wbg_rand::{Rng, wasm_rng, math_random_rng};
+//!
+//! // get random boolean, `math_random_rng()` samples `Math.random` in JS every call
+//! let a: bool = math_random_rng().gen();
+//! println!("{}", a);
+//!
+//! // `wasm_rng()` only samples `Math.random` to re-seed periodically
+//! let n = wasm_rng().gen::<f64>();
+//! println!("{}", n);
+//!
+//! let r: usize = wasm_rng().gen_range(0, 10);
+//! println!("{}", r);
+//! ```
 
 #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
-extern crate wasm_bindgen;
 extern crate rand;
+extern crate wasm_bindgen;
 #[macro_use]
 extern crate lazy_static;
 


### PR DESCRIPTION
README was referencing `wasm_rand`, but it's actually `wasm_rng`. 

Also added some example usages to get people started!